### PR TITLE
Updated snapcraft.yaml to work with beta versions

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -45,7 +45,7 @@ parts:
     override-build: |
       wget --quiet https://api.github.com/repos/00-Evan/shattered-pixel-dungeon/releases -O releases.json
       VERSION=$(jq . releases.json | grep tag_name | cut -d'"' -f4 | sed s'/v//' | head -n 1)
-      JAR_URL=$(grep browser_download releases.json | grep "download/v${VERSION}" | grep jar | cut -d'"' -f4 | tail -n 1)
+      JAR_URL=$(grep browser_download releases.json | grep -P "download/v?${VERSION}" | grep jar | cut -d'"' -f4 | tail -n 1)
       wget -O $SNAPCRAFT_PART_INSTALL/ShatteredPD.Desktop.v$VERSION.jar $JAR_URL
       snapcraftctl set-version "$VERSION"
     build-packages:


### PR DESCRIPTION
The latest beta version number does not start with the letter "v". Because of this, the grep doesn't find the download URL.

This fixes that, by making the grep optionally look for the v.

For easily understanding this problem visually, here is a list of the recent versions:

```
releases/download/1.4.0-beta/  <--- This version has no letter v!
releases/download/v1.3.2/
releases/download/v1.2.3/
releases/download/v1.1.2/
releases/download/v1.0.3/
releases/download/v0.9.3c/
```