### PR TITLE
Fix SSL/TLS for News feature by staging ca-certificates-java

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -64,10 +64,10 @@ parts:
     after: [alsa-pulseaudio,launcher]
     build-packages:
       - wget
-    stage-packages:
-      - openjdk-21-jre-headless
       - ca-certificates
       - ca-certificates-java
+    stage-packages:
+      - openjdk-21-jre-headless
     plugin: nil
     override-build: |
       mkdir -p "$SNAPCRAFT_PART_INSTALL/bin"
@@ -75,17 +75,16 @@ parts:
     override-prime: |
       craftctl default
       # openjdk ships cacerts and blacklisted.certs as symlinks pointing into
-      # /etc outside the snap, which the store linter rejects. Replace each
-      # symlink with a real copy of the file from within the prime tree.
+      # /etc outside the snap, which the store linter rejects. ca-certificates-java
+      # is a post-install hook package so its files live on the host, not in the
+      # prime tree. Find all such external symlinks and replace them with real
+      # copies sourced directly from the host filesystem.
       find usr/lib/jvm -name "cacerts" -o -name "blacklisted.certs" | while read link; do
         if [ -L "$link" ]; then
-          # Resolve relative to the prime directory, not the host filesystem
-          target=$(readlink "$link")
-          # Strip leading / to make it relative to prime tree
-          target_rel="${target#/}"
-          if [ -f "$target_rel" ]; then
+          target=$(readlink -f "$link")
+          if [ -f "$target" ]; then
             rm "$link"
-            cp "$target_rel" "$link"
+            cp "$target" "$link"
           fi
         fi
       done

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -72,3 +72,17 @@ parts:
     override-build: |
       mkdir -p "$SNAPCRAFT_PART_INSTALL/bin"
       wget -O "$SNAPCRAFT_PART_INSTALL/bin/Shattered_Pixel_Dungeon.jar" "https://github.com/00-Evan/shattered-pixel-dungeon/releases/download/$SNAPCRAFT_PROJECT_VERSION/ShatteredPD-$SNAPCRAFT_PROJECT_VERSION-Java.jar"
+    override-prime: |
+      craftctl default
+      # Replace external symlinks with actual file copies so the snap passes store review.
+      # openjdk on core22 ships cacerts and blacklisted.certs as symlinks into /etc,
+      # which the store linter rejects as external symlinks.
+      for link in usr/lib/jvm/java-*/lib/security/cacerts usr/lib/jvm/java-*/lib/security/blacklisted.certs; do
+        if [ -L "$link" ]; then
+          target=$(readlink -f "$link" 2>/dev/null || true)
+          if [ -f "$target" ]; then
+            rm "$link"
+            cp "$target" "$link"
+          fi
+        fi
+      done

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -74,15 +74,18 @@ parts:
       wget -O "$SNAPCRAFT_PART_INSTALL/bin/Shattered_Pixel_Dungeon.jar" "https://github.com/00-Evan/shattered-pixel-dungeon/releases/download/$SNAPCRAFT_PROJECT_VERSION/ShatteredPD-$SNAPCRAFT_PROJECT_VERSION-Java.jar"
     override-prime: |
       craftctl default
-      # Replace external symlinks with actual file copies so the snap passes store review.
-      # openjdk on core22 ships cacerts and blacklisted.certs as symlinks into /etc,
-      # which the store linter rejects as external symlinks.
-      for link in usr/lib/jvm/java-*/lib/security/cacerts usr/lib/jvm/java-*/lib/security/blacklisted.certs; do
+      # openjdk ships cacerts and blacklisted.certs as symlinks pointing into
+      # /etc outside the snap, which the store linter rejects. Replace each
+      # symlink with a real copy of the file from within the prime tree.
+      find usr/lib/jvm -name "cacerts" -o -name "blacklisted.certs" | while read link; do
         if [ -L "$link" ]; then
-          target=$(readlink -f "$link" 2>/dev/null || true)
-          if [ -f "$target" ]; then
+          # Resolve relative to the prime directory, not the host filesystem
+          target=$(readlink "$link")
+          # Strip leading / to make it relative to prime tree
+          target_rel="${target#/}"
+          if [ -f "$target_rel" ]; then
             rm "$link"
-            cp "$target" "$link"
+            cp "$target_rel" "$link"
           fi
         fi
       done

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -66,9 +66,9 @@ parts:
       - wget
     stage-packages:
       - openjdk-21-jre-headless
+      - ca-certificates
+      - ca-certificates-java
     plugin: nil
     override-build: |
       mkdir -p "$SNAPCRAFT_PART_INSTALL/bin"
       wget -O "$SNAPCRAFT_PART_INSTALL/bin/Shattered_Pixel_Dungeon.jar" "https://github.com/00-Evan/shattered-pixel-dungeon/releases/download/$SNAPCRAFT_PROJECT_VERSION/ShatteredPD-$SNAPCRAFT_PROJECT_VERSION-Java.jar"
-    prime:
-      - -usr/lib/jvm/java-*/lib/security/cacerts


### PR DESCRIPTION
The snap was excluding `cacerts` from the prime step:

```yaml
prime:
  - -usr/lib/jvm/java-*/lib/security/cacerts
```

This left Java with an empty trust store, causing an `SSLException` with `trustAnchors parameter must be non-empty` when the game tries to fetch News over HTTPS.

The fix: remove the prime exclusion and add `ca-certificates` and `ca-certificates-java` as stage-packages. This properly sets up the Java trust store using system CA certs — the same approach used in popey/mindustry-snap.

Fixes #5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes HTTPS News fetching by building Java CA certs into the snap and replacing OpenJDK external symlinks with real files.

Removes the `cacerts` prime exclusion, moves `ca-certificates` and `ca-certificates-java` to `build-packages`, and in `override-prime` copies the resolved `cacerts`/`blacklisted.certs` targets from the host into the prime tree so Java’s trust store is present and no external symlinks remain.

<sup>Written for commit c384f638b823a85579a616d1e72044c7fcd913c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

