### PR TITLE
Add smoke test: launch snap in VM and capture screenshot

### DIFF
--- a/.github/workflows/test-snap-can-build.yml
+++ b/.github/workflows/test-snap-can-build.yml
@@ -1,4 +1,4 @@
-name: 🧪 Build and smoke test snap
+name: Build and smoke test snap
 
 on:
   push:
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   build:
-    name: 🔨 Build snap
+    name: Build snap
     runs-on: ubuntu-latest
 
     steps:
@@ -42,7 +42,7 @@ jobs:
           retention-days: 7
 
   smoke-test:
-    name: 💨 Smoke test (launch + screenshot)
+    name: Smoke test (launch + screenshot)
     runs-on: ubuntu-latest
     needs: build
 
@@ -115,7 +115,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `### 🧪 Smoke test ✅
-
-Snap launched in a VM. 📸 Download \`smoke-test-screenshots\` from the [run](${runUrl}) to view.`
+              body: `### Smoke test\n\nSnap launched in a VM. Screenshots available as the \`smoke-test-screenshots\` artifact on the [run](${runUrl}).`
             });

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # shattered-pixel-dungeon-snap
+[![shattered-pixel-dungeon](https://github.com/popey/shattered-pixel-dungeon-snap/actions/workflows/test-snap-can-build.yml/badge.svg)](https://github.com/popey/shattered-pixel-dungeon-snap/actions)
 
 [![shattered-pixel-dungeon](https://snapcraft.io/shattered-pixel-dungeon/badge.svg)](https://snapcraft.io/shattered-pixel-dungeon)
 [![shattered-pixel-dungeon](https://snapcraft.io/shattered-pixel-dungeon/trending.svg?name=0)](https://snapcraft.io/shattered-pixel-dungeon)


### PR DESCRIPTION
Adds a second CI job after a successful build that installs the snap into a fresh LXD desktop VM (via [ghvmctl](https://github.com/snapcrafters/ghvmctl)), launches `shattered-pixel-dungeon`, waits 30s, takes screenshots and uploads them as workflow artifacts.

Same approach used by [snapcrafters/ci](https://github.com/snapcrafters/ci).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CI smoke test that installs the built snap in a fresh LXD desktop VM via `ghvmctl`, launches `shattered-pixel-dungeon`, waits ~30s, and uploads screenshots as artifacts. Also removes emoji from workflow text to avoid UTF‑8 issues and adds a CI status badge to the README.

- **New Features**
  - Add `smoke-test` job: provisions an LXD VM with `ghvmctl`, installs and launches the snap, then saves screenshots as the `smoke-test-screenshots` artifact.

- **Bug Fixes**
  - Remove emoji from workflow names and PR comment body to prevent YAML/UTF‑8 encoding errors.

<sup>Written for commit c01ebb54dc5e90090df5e8b23e73e7b1751f8017. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

